### PR TITLE
Refactor add button into reusable component and improve UI on Kids and Sleeps screens

### DIFF
--- a/SleepyKid.xcodeproj/project.pbxproj
+++ b/SleepyKid.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		901AD9632DE0AEC100263A44 /* SleepyKidTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = SleepyKidTests; sourceTree = "<group>"; };
+		908C43392E3A1E2000FA4C06 /* Components */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Components; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -344,6 +345,7 @@
 				9029A6522BDBB30F002864AC /* Sleep */,
 				9029A64A2BDBABD6002864AC /* KidsList */,
 				90EC4A012BDBE71000DEBAFF /* SleepsList */,
+				908C43392E3A1E2000FA4C06 /* Components */,
 				9064B4022BF0D6F200E795E7 /* Helpers */,
 				9064B4012BF0D66B00E795E7 /* Constants */,
 				9029A6472BDBA22F002864AC /* Extentions */,
@@ -447,6 +449,9 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				908C43392E3A1E2000FA4C06 /* Components */,
 			);
 			name = SleepyKid;
 			packageProductDependencies = (

--- a/SleepyKid/Components/FloatingAddButton.swift
+++ b/SleepyKid/Components/FloatingAddButton.swift
@@ -1,0 +1,50 @@
+//
+//  FloatingAddButton.swift
+//  SleepyKid
+//
+//  Created by ozinchenko.dev on 30/07/2025.
+//
+
+import UIKit
+import SnapKit
+
+final class FloatingAddButton: UIView {
+    // MARK: - GUI Variables
+    let button: UIButton = {
+        let button = UIButton(type: .custom)
+        button.backgroundColor = .orange
+        button.setTitle("+", for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.titleLabel?.font = UIFont(name: "Poppins-Regular",
+                                         size: Layer.actionButtonTitleSize.rawValue)
+        button.layer.cornerRadius = Layer.actionButtonCornerRadius.rawValue
+        button.layer.shadowColor = UIColor.black.cgColor
+        button.layer.shadowOpacity = 0.2
+        button.layer.shadowOffset = CGSize(width: 0, height: 2)
+        button.layer.shadowRadius = Layer.actionButtonssHadowRadius.rawValue
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    // MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup
+    private func setupUI() {
+        addSubview(button)
+        setupConstraints()
+    }
+    
+    private func setupConstraints() {
+        button.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}

--- a/SleepyKid/Constants/Layer.swift
+++ b/SleepyKid/Constants/Layer.swift
@@ -13,4 +13,8 @@ enum Layer: CGFloat {
     case screenTitleFontSize = 18
     case labelFontSizeLarge = 17
     case labelFontSizeSmall = 15
+    case actionButtonTitleSize = 44
+    case actionButtonSize = 54
+    case actionButtonCornerRadius = 27
+    case actionButtonssHadowRadius = 4
 }

--- a/SleepyKid/KidsList/View/KidsListViewController.swift
+++ b/SleepyKid/KidsList/View/KidsListViewController.swift
@@ -9,9 +9,20 @@ import UIKit
 
 class KidsListViewController: UIViewController {
     // MARK: - GUI Variables
+    private let tableHeaderLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Kids".uppercased()
+        label.font = UIFont(name: "Poppins-Bold", size: Layer.screenTitleFontSize.rawValue)
+        label.textColor = .label
+        return label
+    }()
+    
     private let tableView: UITableView = {
         let tableView = UITableView()
+        tableView.separatorStyle = .none
         tableView.backgroundColor = .athensGray
+        tableView.register(KidTableViewCell.self,
+                           forCellReuseIdentifier: "KidTableViewCell")
         return tableView
     }()
     
@@ -79,23 +90,15 @@ class KidsListViewController: UIViewController {
     }
     
     private func setupTableHeader() {
-        let label = UILabel()
-        label.text = "Kids".uppercased()
-        label.font = UIFont(name: "Poppins-Bold", size: Layer.screenTitleFontSize.rawValue)
-        label.textColor = .label
-        
-        navigationItem.titleView = label
+        navigationItem.titleView = tableHeaderLabel
         addButton.addTarget(self, action: #selector(addButtonTapped), for: .touchUpInside)
     }
     
     private func setupTableView() {
-        tableView.register(KidTableViewCell.self,
-                           forCellReuseIdentifier: "KidTableViewCell")
-        tableView.separatorStyle = .none
-        setupTableHeader()
         tableView.dataSource = self
         tableView.delegate = self
         
+        setupTableHeader()
     }
     
     private func registerObserver() {

--- a/SleepyKid/KidsList/View/KidsListViewController.swift
+++ b/SleepyKid/KidsList/View/KidsListViewController.swift
@@ -26,24 +26,21 @@ class KidsListViewController: UIViewController {
         return tableView
     }()
     
-    private let addButton: UIButton = {
-        let button = UIButton(type: .custom)
-        button.backgroundColor = .orange
-        button.setTitle("+", for: .normal)
-        button.setTitleColor(.white, for: .normal)
-        button.titleLabel?.font = UIFont(name: "Poppins-Regular",
-                                         size: Layer.actionButtonTitleSize.rawValue)
-        button.layer.cornerRadius = Layer.actionButtonCornerRadius.rawValue
-        button.layer.shadowColor = UIColor.black.cgColor
-        button.layer.shadowOpacity = 0.2
-        button.layer.shadowOffset = CGSize(width: 0, height: 2)
-        button.layer.shadowRadius = Layer.actionButtonssHadowRadius.rawValue
-        return button
-    }()
+    private let addButton = FloatingAddButton()
     
     // MARK: - Properties
     var viewModel: KidsListViewModelProtocol
     weak var coordinator: AppCoordinator?
+    
+    // MARK: - Initialization
+    init(viewModel: KidsListViewModelProtocol) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     // MARK: - Live Cycle
     override func viewWillAppear(_ animated: Bool) {
@@ -68,16 +65,6 @@ class KidsListViewController: UIViewController {
         self.navigationController?.toolbar.isHidden = false
     }
     
-    // MARK: - Initialization
-    init(viewModel: KidsListViewModelProtocol) {
-        self.viewModel = viewModel
-        super.init(nibName: nil, bundle: nil)
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
     // MARK: - Private Methods
     private func setupUI() {
         view.backgroundColor = .athensGray
@@ -87,11 +74,11 @@ class KidsListViewController: UIViewController {
         setupTableView()
         setupConstraints()
         registerObserver()
+        addTargets()
     }
     
     private func setupTableHeader() {
         navigationItem.titleView = tableHeaderLabel
-        addButton.addTarget(self, action: #selector(addButtonTapped), for: .touchUpInside)
     }
     
     private func setupTableView() {
@@ -108,6 +95,10 @@ class KidsListViewController: UIViewController {
                                                object: nil)
     }
     
+    private func addTargets() {
+        addButton.button.addTarget(self, action: #selector(addButtonTapped), for: .touchUpInside)
+    }
+    
     private func setupConstraints() {
         addButton.snp.makeConstraints {
             $0.height.width.equalTo(Layer.actionButtonSize.rawValue)
@@ -120,7 +111,6 @@ class KidsListViewController: UIViewController {
         }
     }
     
-    
     @objc private func addButtonTapped() {
         coordinator?.showKidViewController(for: nil)
     }
@@ -130,16 +120,16 @@ class KidsListViewController: UIViewController {
         viewModel.getKids()
     }
 }
-
+ 
 // MARK: - UITableViewDataSource
 extension KidsListViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView,
-                            numberOfRowsInSection section: Int) -> Int {
+                   numberOfRowsInSection section: Int) -> Int {
         viewModel.kids.count
     }
     
     func tableView(_ tableView: UITableView,
-                            cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+                   cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "KidTableViewCell",
                                                        for: indexPath) as? KidTableViewCell
         else { return UITableViewCell() }
@@ -156,15 +146,16 @@ extension KidsListViewController: UITableViewDataSource {
 // MARK: - UITableViewDelegate
 extension KidsListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView,
-                            didSelectRowAt indexPath: IndexPath) {
+                   didSelectRowAt indexPath: IndexPath) {
         let kid = viewModel.getKid(for: indexPath.row)
         let startDate = viewModel.getStartDate(for: kid)
         coordinator?.showSleepsListViewController(for: kid, startDate: startDate)
     }
     
-    func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt
-                            indexPath: IndexPath,
-                            point: CGPoint) -> UIContextMenuConfiguration? {
+    func tableView(_ tableView: UITableView,
+                   contextMenuConfigurationForRowAt
+                   indexPath: IndexPath,
+                   point: CGPoint) -> UIContextMenuConfiguration? {
         let kid = viewModel.getKid(for: indexPath.row)
         let kidViewModel = KidViewModel(kid: kid)
         let provider: UIContextMenuActionProvider = { _ in

--- a/SleepyKid/Resources/Base.lproj/LaunchScreen.storyboard
+++ b/SleepyKid/Resources/Base.lproj/LaunchScreen.storyboard
@@ -24,7 +24,7 @@
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="SleepyKid" translatesAutoresizingMaskIntoConstraints="NO" id="CzF-Ea-zNs">
                                 <rect key="frame" x="50" y="368" width="293" height="96"/>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SleepyKid" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zAs-tW-bu9">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SleepyKid" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zAs-tW-bu9">
                                 <rect key="frame" x="30" y="472" width="333" height="45"/>
                                 <fontDescription key="fontDescription" name="Poppins-Bold" family="Poppins" pointSize="32"/>
                                 <nil key="textColor"/>

--- a/SleepyKid/Sleep/View/SleepViewController.swift
+++ b/SleepyKid/Sleep/View/SleepViewController.swift
@@ -183,8 +183,5 @@ final class SleepViewController: UIViewController {
             endDate: endSleepDatePicker.date
         )
         setSleep(sleep: updatedSleep, number: viewModel.sleepNumber)
-        
-//        let sleepNumber = viewModel.getSleepNumber(date: updatedSleep.startDate)
-//        setSleep(sleep: updatedSleep, number: sleepNumber)
     }
 }

--- a/SleepyKid/SleepsList/View/SleepsListHeader.swift
+++ b/SleepyKid/SleepsList/View/SleepsListHeader.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 
-
 protocol SleepsListHeaderDelegate: AnyObject {
   func sleepsListHeader(_ header: SleepsListHeader, didPick date: Date)
 }


### PR DESCRIPTION
This PR introduces several improvements and refactors across the KidsList and SleepsList screens:

- Extracted the floating add button into a reusable FloatingAddButton component for use across multiple screens.
- Updated the design and layout of the add button to ensure consistent styling and placement.
- Hid the toolbar when entering the KidsList and SleepsList screens to reduce UI clutter.
- Refactored the tableHeaderLabel and applied layout cleanups for better structure and clarity.
- Removed redundant code.

These changes improve code reusability, reduce duplication, and enhance the visual consistency of the app’s UI.