### PR TITLE
Add a refresh data mechanism on the SleepsList screen

### DIFF
--- a/SleepyKid/KidsList/View/KidsListViewController.swift
+++ b/SleepyKid/KidsList/View/KidsListViewController.swift
@@ -179,8 +179,7 @@ extension KidsListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView,
                    didSelectRowAt indexPath: IndexPath) {
         let kid = viewModel.getKid(for: indexPath.row)
-        let startDate = viewModel.getStartDate(for: kid)
-        coordinator?.showSleepsListViewController(for: kid, startDate: startDate)
+        coordinator?.showSleepsListViewController(for: kid, startDate: .now)
     }
     
     func tableView(_ tableView: UITableView,

--- a/SleepyKid/KidsList/ViewModel/KidsListViewModel.swift
+++ b/SleepyKid/KidsList/ViewModel/KidsListViewModel.swift
@@ -16,7 +16,6 @@ protocol KidsListViewModelProtocol {
     func getKids()
     func getKid(for row: Int) -> Kid
     func getKidAdge(for row: Int) -> String
-    func getStartDate(for kid: Kid) -> Date
 }
 
 final class KidsListViewModel: KidsListViewModelProtocol {
@@ -56,13 +55,5 @@ final class KidsListViewModel: KidsListViewModelProtocol {
     func getKidAdge(for row: Int) -> String {
         let kid = getKid(for: row)
         return DateHelper.shared.getKidAge(birthDate: kid.birthDate)
-    }
-    
-    func getStartDate(for kid: Kid) -> Date {
-        if let firstSleep = kid.sleeps.min(by: { $0.startDate < $1.startDate }) {
-            return firstSleep.startDate
-        } else {
-            return .now
-        }
     }
 }


### PR DESCRIPTION
**Summary**
This PR introduces a data refresh mechanism on the SleepsList screen.

**Changes**
- Added UIRefreshControl to support pull-to-refresh.
- Subscribed to foreground/active app notifications to auto-refresh data when returning from background.
- Unified refresh logic into a single updateData() method.
- Ensured refresh spinner ends correctly after reload.

**Notes**
Improves UX by keeping the Sleeps list always up to date with the latest data.